### PR TITLE
Add main PHOCKS asset

### DIFF
--- a/phockheads.json
+++ b/phockheads.json
@@ -65,6 +65,7 @@
 "PHOCKHEADS.STEVEAOKI":"https://i.imgur.com/8gneXkE.gif",
 "PHOCKHEADS.XCOPY":"https://i.imgur.com/DMgtvYN.gif",
 "PHOCKHEADS.LORDGLEN":"https://i.imgur.com/BcnJZpi.gif",
+"PHOCKS":"https://i.imgur.com/LQg12IQ.jpg",
 "PHOCKS.MARIO":"https://i.imgur.com/strblhm.jpg",
 "PHOCKS.LUIGI":"https://i.imgur.com/uh5Mvzr.jpg",
 "PHOCKS.ORANGEMAN":"https://i.imgur.com/MMZ6ode.jpg",


### PR DESCRIPTION
The main PHOCKS asset is missing from the json file. This PR adds it to the list.